### PR TITLE
Fork and add a Dial method

### DIFF
--- a/.godocdown.tmpl
+++ b/.godocdown.tmpl
@@ -1,3 +1,0 @@
-[![GoDoc](https://godoc.org/github.com/pdf/websocketrwc?status.svg)](http://godoc.org/github.com/pdf/websocketrwc) ![License-MIT](http://img.shields.io/badge/license-MIT-red.svg)
-
-{{ .Emit }}

--- a/README.md
+++ b/README.md
@@ -1,8 +1,10 @@
-[![GoDoc](https://godoc.org/github.com/pdf/websocketrwc?status.svg)](http://godoc.org/github.com/pdf/websocketrwc) ![License-MIT](http://img.shields.io/badge/license-MIT-red.svg)
-
 # websocketrwc
+
+Fork of https://github.com/pdf/websocketrwc/tree/master
+Forked so we can add a client Dial method
+
 --
-    import "github.com/pdf/websocketrwc"
+    import "github.com/artisaninsight/websocketrwc"
 
 Package websocketrwc wraps Gorilla websocket in an io.ReadWriteCloser compatible
 interface, allowing it to be used as a net/rpc or similar connection. Only the

--- a/glide.lock
+++ b/glide.lock
@@ -1,6 +1,0 @@
-hash: 6b37ec1dd873b5933b49b3ecd10d3a6be53984d701529a0366a95ae7b5e28abb
-updated: 2017-02-04T09:41:23.580633057+11:00
-imports:
-- name: github.com/gorilla/websocket
-  version: 3ab3a8b8831546bd18fd182c20687ca853b2bb13
-testImports: []

--- a/glide.yaml
+++ b/glide.yaml
@@ -1,4 +1,0 @@
-package: github.com/pdf/websocketrwc
-import:
-- package: github.com/gorilla/websocket
-  version: ^1.1.0

--- a/go.mod
+++ b/go.mod
@@ -1,0 +1,5 @@
+module github.com/ArtisanInsight/websocketrwc
+
+go 1.23.1
+
+require github.com/gorilla/websocket v1.5.3

--- a/go.sum
+++ b/go.sum
@@ -1,0 +1,2 @@
+github.com/gorilla/websocket v1.5.3 h1:saDtZ6Pbx/0u+bgYQ3q96pZgCzfhKXGPqt7kZ72aNNg=
+github.com/gorilla/websocket v1.5.3/go.mod h1:YR8l580nyteQvAITg2hZ9XVh4b55+EU/adAjf1fMHhE=

--- a/websocketrwc.go
+++ b/websocketrwc.go
@@ -37,7 +37,7 @@ var (
 	// PongTimeout determines the period of time a connection will wait for a
 	// Pong response to Pings sent to the client.
 	PongTimeout = 60 * time.Second
-	// PingInterval determins the interval at which Pings are sent to the
+	// PingInterval determines the interval at which Pings are sent to the
 	// client.
 	PingInterval = (PongTimeout * 9) / 10
 )
@@ -234,7 +234,11 @@ func Dial(addr string, dialer *websocket.Dialer) (*Conn, error) {
 		return conn.ws.SetReadDeadline(time.Now().Add(PongTimeout))
 	})
 
-	// Start ping loop for client keep-alive.
-	go conn.pinger()
+	// Respond to Ping with a Pong
+	conn.ws.SetPingHandler(func(appData string) error {
+		fmt.Printf("received ping")
+		return conn.ws.WriteControl(websocket.PongMessage, []byte{}, time.Now().Add(WriteTimeout))
+	})
+
 	return conn, nil
 }


### PR DESCRIPTION
Forking a package in order to make this more useful. I've added a Dial method so we can use this as a client.
This adds Read/Write/Close methods which make up the most common golang interfaces. This lets us use the websocket client in a lot of various ways using existing tools

- **Remove glide and use go mod**
- **Update Readme and remove godoc**
- **add Dial method to use this as a client**
